### PR TITLE
Allow ssl_opts to be overridden when updating

### DIFF
--- a/lib/nerves_hub_link_http.ex
+++ b/lib/nerves_hub_link_http.ex
@@ -1,26 +1,51 @@
 defmodule NervesHubLinkHTTP do
+  @moduledoc """
+  Official client to use HTTP polling for firmware updates from NervesHub
+  """
+
   require Logger
 
   alias NervesHubLinkHTTP.{Client, HTTPFwupStream}
 
-  def update do
-    case Client.update() do
-      {:ok, %{"data" => %{"update_available" => true, "firmware_url" => url}}} ->
-        Logger.info("[NervesHubLinkHTTP] Downloading firmware: #{url}")
-        {:ok, http} = HTTPFwupStream.start_link(self())
-        # Spawn to allow async messages from FWUP.
-        spawn_monitor(HTTPFwupStream, :get, [http, url])
-        update_receive()
+  @doc """
+  Check for an available update.
 
-      {:ok, %{"data" => %{"update_available" => false}}} ->
-        :no_update
-
-      {:error, _} = err ->
-        err
+  The update is not automatically applied.
+  """
+  @spec update?(Keyword.t()) :: {:ok, String.t()} | {:ok, :no_update} | {:error, any()}
+  def update?(opts \\ []) do
+    case Client.update(opts) do
+      {:ok, %{"data" => %{"update_available" => true, "firmware_url" => url}}} -> {:ok, url}
+      {:ok, %{"data" => %{"update_available" => false}}} -> {:ok, :no_update}
+      {:error, _} = err -> err
     end
   end
 
-  def update_receive() do
+  @doc """
+  Apply the update at the provided `url`.
+  """
+  @spec apply_update(String.t()) :: no_return()
+  def apply_update(url) when is_binary(url) do
+    Logger.info("[NervesHubLinkHTTP] Downloading firmware: #{url}")
+    {:ok, http} = HTTPFwupStream.start_link(self())
+    # Spawn to allow async messages from FWUP.
+    spawn_monitor(HTTPFwupStream, :get, [http, url])
+    update_receive()
+  end
+
+  @doc """
+  Check for an available update and automatically apply it.
+  """
+  @spec update(Keyword.t()) :: no_return() | :no_update | {:error, any()}
+  def update(opts \\ []) do
+    case update?(opts) do
+      {:ok, :no_update} -> :no_update
+      {:ok, url} when is_binary(url) -> apply_update(url)
+      {:error, _} = err -> err
+    end
+  end
+
+  defp update_receive() do
     receive do
       # Reboot when FWUP is done applying the update.
       {:fwup, {:ok, 0, message}} ->


### PR DESCRIPTION
Why
---

- Flexibility for consumers.

How
---

- Accept `opts` in `NervesHubLinkHTTP.update` and pass them along.