### PR TITLE
Report FWUP version to NervesHub

### DIFF
--- a/lib/nerves_hub_link_http/client.ex
+++ b/lib/nerves_hub_link_http/client.ex
@@ -132,7 +132,7 @@ defmodule NervesHubLinkHTTP.Client do
   end
 
   defp headers do
-    headers = [{"Content-Type", "application/json"}]
+    headers = [{"X-NervesHub-fwup-version", fwup_version()}, {"Content-Type", "application/json"}]
 
     Nerves.Runtime.KV.get_all_active()
     |> Enum.reduce(headers, fn
@@ -174,5 +174,10 @@ defmodule NervesHubLinkHTTP.Client do
       key: {:ECPrivateKey, key},
       server_name_indication: to_charlist(sni)
     ]
+  end
+
+  defp fwup_version do
+    {version_string, 0} = System.cmd("fwup", ["--version"])
+    String.trim(version_string)
   end
 end

--- a/test/nerves_hub_link_http/client_test.exs
+++ b/test/nerves_hub_link_http/client_test.exs
@@ -91,6 +91,14 @@ defmodule NervesHubLinkHTTP.ClientTest do
 
       assert Client.request(:get, "/path", []) == {:ok, :response}
     end
+
+    test "fwup_version is sent with headers" do
+      Mox.expect(ClientMock, :request, fn :get, _, [{"X-NervesHub-fwup-version", _} | _], _, _ ->
+        {:ok, :response}
+      end)
+
+      assert Client.request(:get, "/path", []) == {:ok, :response}
+    end
   end
 
   test "url/1" do


### PR DESCRIPTION
Why:

* NH will need to know the FWUP version to make decisions about delta updates

This change addresses the need by:

* Adding a function for getting fwup version
* Adding the fwup version to the default headers
* Adding a test to verify header is sent